### PR TITLE
Fix actor warnings + add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  swift:
+    name: SwiftPM
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run tests
+        run: make verify-swift
+
+      - name: Build example product
+        run: swift build --product YiTongExample
+
+  web:
+    name: WebRenderer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: WebRenderer/package-lock.json
+
+      - name: Install dependencies
+        run: cd WebRenderer && npm ci
+
+      - name: Build
+        run: cd WebRenderer && npm run build

--- a/Sources/YiTongCore/YiTongWebViewHost.swift
+++ b/Sources/YiTongCore/YiTongWebViewHost.swift
@@ -7,6 +7,19 @@ import YiTongWebAssets
 public final class YiTongWebViewHost: NSObject {
   public typealias EventHandler = @Sendable (YiTongHostEvent) -> Void
 
+  @MainActor
+  private final class WeakScriptMessageHandler: NSObject, WKScriptMessageHandler {
+    weak var delegate: (any WKScriptMessageHandler)?
+
+    init(delegate: (any WKScriptMessageHandler)? = nil) {
+      self.delegate = delegate
+    }
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+      delegate?.userContentController(userContentController, didReceive: message)
+    }
+  }
+
   private enum Constants {
     static let scriptMessageHandlerName = "yitongBridge"
     static let diagnosticMessageHandlerName = "yitongDiagnostic"
@@ -55,6 +68,8 @@ public final class YiTongWebViewHost: NSObject {
   }
 
   public let webView: WKWebView
+  private let bridgeHandlerProxy: WeakScriptMessageHandler
+  private let diagnosticHandlerProxy: WeakScriptMessageHandler?
   private let platform: YiTongBridgePlatform
   private let diagnosticsEnabled: Bool
   private var coordinator = YiTongRendererCoordinator()
@@ -79,10 +94,20 @@ public final class YiTongWebViewHost: NSObject {
     }
     configuration.userContentController = userContentController
     self.webView = WKWebView(frame: .zero, configuration: configuration)
+
+    let bridgeHandlerProxy = WeakScriptMessageHandler()
+    let diagnosticHandlerProxy = self.diagnosticsEnabled ? WeakScriptMessageHandler() : nil
+    self.bridgeHandlerProxy = bridgeHandlerProxy
+    self.diagnosticHandlerProxy = diagnosticHandlerProxy
+
     super.init()
-    userContentController.add(self, name: Constants.scriptMessageHandlerName)
-    if self.diagnosticsEnabled {
-      userContentController.add(self, name: Constants.diagnosticMessageHandlerName)
+
+    bridgeHandlerProxy.delegate = self
+    userContentController.add(bridgeHandlerProxy, name: Constants.scriptMessageHandlerName)
+
+    if diagnosticsEnabled, let diagnosticHandlerProxy {
+      diagnosticHandlerProxy.delegate = self
+      userContentController.add(diagnosticHandlerProxy, name: Constants.diagnosticMessageHandlerName)
     }
     webView.navigationDelegate = self
 #if os(macOS)
@@ -93,18 +118,6 @@ public final class YiTongWebViewHost: NSObject {
     webView.scrollView.backgroundColor = .clear
 #endif
   }
-
-  deinit {
-    let userContentController = webView.configuration.userContentController
-    let diagnosticsEnabled = diagnosticsEnabled
-    MainActor.assumeIsolated {
-      userContentController.removeScriptMessageHandler(forName: Constants.scriptMessageHandlerName)
-      if diagnosticsEnabled {
-        userContentController.removeScriptMessageHandler(forName: Constants.diagnosticMessageHandlerName)
-      }
-    }
-  }
-
   public func setEventHandler(_ handler: EventHandler?) {
     eventHandler = handler
   }

--- a/Tests/YiTongTests/YiTongTests.swift
+++ b/Tests/YiTongTests/YiTongTests.swift
@@ -138,6 +138,7 @@ final class YiTongTests: XCTestCase {
     )
   }
 
+  @MainActor
   func testDiffViewCanBeConstructed() {
     let document = DiffDocument(patch: "diff --git a/a.txt b/a.txt")
     let view = DiffView(document: document)


### PR DESCRIPTION
This PR:

- Fixes Swift concurrency warnings by avoiding `WKWebView` main-actor properties access from `deinit`.
  - Introduces a weak proxy `WKScriptMessageHandler` to avoid strong reference cycles.
- Marks the SwiftUI `DiffView` construction test as `@MainActor`.
- Adds GitHub Actions CI:
  - SwiftPM: `make verify-swift` + build `YiTongExample` (macos runner)
  - WebRenderer: `npm ci` + `npm run build` (ubuntu runner)

Verification:
- `make verify-swift` (34 tests) ✅
- `npm ci && npm run build` in `WebRenderer/` ✅
